### PR TITLE
Added logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
 			<!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
 			<id>openshift</id>
 			<build>
-				<finalName>mlbparks</finalName>
+				<finalName>openshift-tasks</finalName>
 				<plugins>
 					<plugin>
 						<artifactId>maven-war-plugin</artifactId>

--- a/src/main/java/com/openshift/service/DemoResource.java
+++ b/src/main/java/com/openshift/service/DemoResource.java
@@ -56,7 +56,7 @@ public class DemoResource {
     @GET
     @Path("killswitch/")
     @Produces({"application/json"})
-    public String killSwitch(@Context SecurityContext context, @PathParam("number") int number) {
+    public String killSwitch(@Context SecurityContext context) {
         System.exit(1);
         return new String("Added a log statement of type WARNING");
     }

--- a/src/main/java/com/openshift/service/DemoResource.java
+++ b/src/main/java/com/openshift/service/DemoResource.java
@@ -1,13 +1,16 @@
 package com.openshift.service;
 
+import com.openshift.helpers.Load;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import com.openshift.helpers.Load;
 /**
  * A JAX-RS resource for exposing REST endpoints for Task manipulation
  */
@@ -16,12 +19,40 @@ public class DemoResource {
 
     @GET
     @Path("load/{seconds}")
-    @Produces({ "application/json" })
+    @Produces({"application/json"})
     public String generateLoad(@Context SecurityContext context, @PathParam("seconds") int seconds) {
-    	Load cpuLoad = new Load();
-    	cpuLoad.generateLoad(seconds*1000);
+        Load cpuLoad = new Load();
+        cpuLoad.generateLoad(seconds * 1000);
         return new String("Load generated for " + seconds + " seconds.");
     }
-    
+
+    @GET
+    @Path("log/info/{number}")
+    @Produces({"application/json"})
+    public String logInfo(@Context SecurityContext context, @PathParam("number") int number) {
+        Logger log = Logger.getLogger(DemoResource.class.getName());
+        log.log(Level.INFO, "OpenShift Information Log");
+        return new String("Added a log statement of type INFO");
+    }
+
+    @GET
+    @Path("log/error/{number}")
+    @Produces({"application/json"})
+    public String logSevere(@Context SecurityContext context, @PathParam("number") int number) {
+        Logger log = Logger.getLogger(DemoResource.class.getName());
+        log.log(Level.SEVERE, "OpenShift Information Log");
+        return new String("Added a log statement of type SEVERE");
+    }
+
+    @GET
+    @Path("log/warning/{number}")
+    @Produces({"application/json"})
+    public String logWarning(@Context SecurityContext context, @PathParam("number") int number) {
+        Logger log = Logger.getLogger(DemoResource.class.getName());
+        log.log(Level.WARNING, "OpenShift Information Log");
+        return new String("Added a log statement of type WARNING");
+    }
+
+
 
 }

--- a/src/main/java/com/openshift/service/DemoResource.java
+++ b/src/main/java/com/openshift/service/DemoResource.java
@@ -31,7 +31,7 @@ public class DemoResource {
     @Produces({"application/json"})
     public String logInfo(@Context SecurityContext context, @PathParam("number") int number) {
         Logger log = Logger.getLogger(DemoResource.class.getName());
-        log.log(Level.INFO, "OpenShift Information Log");
+        log.log(Level.INFO, "OpenShift: A message for INFO purposes");
         return new String("Added a log statement of type INFO");
     }
 
@@ -40,7 +40,7 @@ public class DemoResource {
     @Produces({"application/json"})
     public String logSevere(@Context SecurityContext context, @PathParam("number") int number) {
         Logger log = Logger.getLogger(DemoResource.class.getName());
-        log.log(Level.SEVERE, "OpenShift Information Log");
+        log.log(Level.SEVERE, "OpenShift: This is an error message");
         return new String("Added a log statement of type SEVERE");
     }
 
@@ -49,7 +49,7 @@ public class DemoResource {
     @Produces({"application/json"})
     public String logWarning(@Context SecurityContext context, @PathParam("number") int number) {
         Logger log = Logger.getLogger(DemoResource.class.getName());
-        log.log(Level.WARNING, "OpenShift Information Log");
+        log.log(Level.WARNING, "OpenShift: This is a warning message");
         return new String("Added a log statement of type WARNING");
     }
 

--- a/src/main/java/com/openshift/service/DemoResource.java
+++ b/src/main/java/com/openshift/service/DemoResource.java
@@ -53,6 +53,13 @@ public class DemoResource {
         return new String("Added a log statement of type WARNING");
     }
 
+    @GET
+    @Path("killswitch/")
+    @Produces({"application/json"})
+    public String killSwitch(@Context SecurityContext context, @PathParam("number") int number) {
+        System.exit(1);
+        return new String("Added a log statement of type WARNING");
+    }
 
 
 }


### PR DESCRIPTION
Added three endpoints for logging and verified they show correctly in the pod log on demo23 env.

To call use one of the following:

http://url/demo/log/$TYPE/$NUMBER

For example:
http://url/demo/log/warning/1
To log a WARN message 1 time.  Replace 

Available types are:
warning, info, error
