### PR TITLE
Add support for maven fabric8 plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,36 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>fabric8-maven-plugin</artifactId>
+                <version>3.5.38</version>
+
+                <configuration>
+                    <images>
+                        <image>
+                            <name>openshift-tasks</name>
+                            <build>
+                                <from>registry.access.redhat.com/jboss-eap-7/eap71-openshift</from>
+                                <assembly>
+                                    <descriptorRef>rootWar</descriptorRef>
+                                    <targetDir>/opt/eap/standalone/deployments</targetDir>
+                                </assembly>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>fmp</id>
+                        <goals>
+                            <goal>resource</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/fabric8/deployment.yml
+++ b/src/main/fabric8/deployment.yml
@@ -1,0 +1,32 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: openshift-tasks
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: tasks
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /ws/demo/healthcheck
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 180
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /ws/demo/healthcheck
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+  triggers:
+    - type: ConfigChange

--- a/src/main/fabric8/route.yml
+++ b/src/main/fabric8/route.yml
@@ -1,0 +1,8 @@
+metadata:
+  name: openshift-tasks
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: openshift-tasks

--- a/src/main/fabric8/service.yml
+++ b/src/main/fabric8/service.yml
@@ -1,0 +1,6 @@
+metadata:
+  name: openshift-tasks
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Add support for maven fabric8 plugin to build & deploy openshift-tasks in openshift.

Currently Fabric8 does not support S2I build for Web applications (.WAR) 
> S2I builds are currently not yet supported for the webapp generator. (Maven Fabric8 Documentation)

Regarding this PR, mvn fabric8 plugin uses OpenShift Docker build capabilities.

Launch openshift-tasks with mvn fabric8 plugin : 

```bash
mvn fabric8:deploy -Dfabric8.build.strategy=docker -DskipTests=true
```